### PR TITLE
Changed confusing Dutch phrasing for required_unless

### DIFF
--- a/nl/validation.php
+++ b/nl/validation.php
@@ -60,7 +60,7 @@ return [
     'regex'                => ':attribute formaat is ongeldig.',
     'required'             => ':attribute is verplicht.',
     'required_if'          => ':attribute is verplicht indien :other gelijk is aan :value.',
-    'required_unless'      => ':attribute is verplicht tenzij :other voorkomt in :values.',
+    'required_unless'      => ':attribute is verplicht tenzij :other gelijk is aan :values.',
     'required_with'        => ':attribute is verplicht i.c.m. :values',
     'required_with_all'    => ':attribute is verplicht i.c.m. :values',
     'required_without'     => ':attribute is verplicht als :values niet ingevuld is.',


### PR DESCRIPTION
The Dutch phrase is confusing, it will say:
`admin password is verplicht tenzij rol voorkomt in admin, moderator`
(`admin password is required unless role occurs in admin, moderator`)

Whereas this makes more sense:
`admin password is verplicht tenzij rol gelijk is aan admin, moderator`
(`admin password is required unless role is equal to admin, moderator`)
